### PR TITLE
changes to prevent manual console commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,3 @@ Alternatively go to the Add-On Store, Click the three dots, then Repositories, a
 ```
 https://github.com/gschmidl/hassio-spoolman
 ```
-
-# Creating the storage directory
-
-You'll need to execute the following in a HA console to create the storage directory. Sorry, I don't know how to do it automatically and all inquiries remained unanswered.
-
-```
-mkdir -p /config/addons_config/spoolman
-chown 1000:1000 /config/addons_config/spoolman
-```

--- a/spoolman/config.yaml
+++ b/spoolman/config.yaml
@@ -1,51 +1,53 @@
-name: "Spoolman Server"
-description: "Run the latest stable version of Spoolman."
-url: "https://github.com/donkie/spoolman"
-slug: "spoolman_server"
+name: Spoolman Server
+description: Run the latest stable version of Spoolman.
+url: https://github.com/donkie/spoolman
+slug: spoolman_server
 init: false
 arch:
   - aarch64
   - amd64
   - armv7
 devices:
-  - "/dev/ttyUSB0"
-  - "/dev/sda"
-  - "/dev/sdb"
-  - "/dev/sdc"
-  - "/dev/sdd"
-  - "/dev/sde"
-  - "/dev/sdf"
-  - "/dev/sdg"
-  - "/dev/fuse"
-  - "/dev/sda1"
-  - "/dev/sdb1"
-  - "/dev/sdc1"
-  - "/dev/sdd1"
-  - "/dev/sde1"
-  - "/dev/sdf1"
-  - "/dev/sdg1"
-  - "/dev/sda2"
-  - "/dev/sdb2"
-  - "/dev/sdc2"
-  - "/dev/sdd2"
-  - "/dev/sde2"
-  - "/dev/sdf2"
-  - "/dev/sdg2"
-  - "/dev/sda3"
-  - "/dev/sdb3"
-  - "/dev/sda4"
-  - "/dev/sdb4"
-  - "/dev/sda5"
-  - "/dev/sda6"
-  - "/dev/sda7"
-  - "/dev/sda8"
+  - /dev/ttyUSB0
+  - /dev/sda
+  - /dev/sdb
+  - /dev/sdc
+  - /dev/sdd
+  - /dev/sde
+  - /dev/sdf
+  - /dev/sdg
+  - /dev/fuse
+  - /dev/sda1
+  - /dev/sdb1
+  - /dev/sdc1
+  - /dev/sdd1
+  - /dev/sde1
+  - /dev/sdf1
+  - /dev/sdg1
+  - /dev/sda2
+  - /dev/sdb2
+  - /dev/sdc2
+  - /dev/sdd2
+  - /dev/sde2
+  - /dev/sdf2
+  - /dev/sdg2
+  - /dev/sda3
+  - /dev/sdb3
+  - /dev/sda4
+  - /dev/sdb4
+  - /dev/sda5
+  - /dev/sda6
+  - /dev/sda7
+  - /dev/sda8
 startup: application
 udev: true
 webui: "[PROTO:option_name]://[HOST]:[PORT:8000]"
 environment:
-  SPOOLMAN_DIR_DATA: "/addon_configs/spoolman"
+  SPOOLMAN_DIR_DATA: "/config"
+  PUID: "0"
+  PGID: "0"
 map:
-  - config:rw  
+  - addon_config:rw
 boot: auto
 ports:
   8000/tcp: 8000


### PR DESCRIPTION
according to [doc ](https://developers.home-assistant.io/docs/add-ons/configuration#add-on-advanced-options) i change config to addon_config in map section, so config dir will be created automatically 

also, i change SPOOLMAN_DIR_DATA enviroment and add PUID, PGID with 0 (It's a dirty trick, but no additional commands needed)